### PR TITLE
Add panic hook to default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+default = ["console_error_panic_hook"]
 multicore = ["pivx_proofs/multicore", "wasm-bindgen-rayon"]
 
 [dependencies]


### PR DESCRIPTION
Reenabled panic hook, even if it adds a small amount of size, the pros outweigh the benefits
