### PR TITLE
Add view only support

### DIFF
--- a/js/pivx_shield.js
+++ b/js/pivx_shield.js
@@ -28,7 +28,7 @@ export class PIVXShield {
    * @param {String?} o.data - ShieldData string in JSON format.
    * @param {Array<Number>?} o.seed - array of 32 bytes that represents a random seed.
    * @param {String?} o.extendedSpendingKey - Extended Spending Key.
-   * @param {Strig?} o.extendedFullViewingKey - Full viewing key
+   * @param {String?} o.extendedFullViewingKey - Full viewing key
    * @param {Number} o.blockHeight - number representing the block height of creation of the wallet
    * @param {Number} o.coinType - number representing the coin type, 1 represents testnet
    * @param {Number} o.accountIndex - index of the account that you want to generate, by default is set to 0
@@ -200,7 +200,7 @@ export class PIVXShield {
   async save() {
     const { address, _ } = await this.callWorker(
       "generate_default_payment_address",
-      this.extsk,
+      this.extfvk,
       this.isTestNet,
     );
 
@@ -222,7 +222,7 @@ export class PIVXShield {
   async load(shieldData) {
     const { address, _ } = await this.callWorker(
       "generate_default_payment_address",
-      this.extsk,
+      this.extfvk,
       this.isTestNet,
     );
     if (address != shieldData.defaultAddress) {

--- a/js/pivx_shield.js
+++ b/js/pivx_shield.js
@@ -322,6 +322,9 @@ export class PIVXShield {
     utxos,
     transparentChangeAddress,
   }) {
+    if (!this.extsk) {
+      throw new Error("You cannot create a transaction in view only mode!");
+    }
     if (!useShieldInputs && !transparentChangeAddress) {
       throw new Error("Change must have the same type of input used!");
     }

--- a/js/pivx_shield.js
+++ b/js/pivx_shield.js
@@ -386,7 +386,7 @@ export class PIVXShield {
   async getNewAddress() {
     const { address, diversifier_index } = await this.callWorker(
       "generate_next_shielding_payment_address",
-      this.extsk,
+      this.extfvk,
       this.diversifierIndex,
       this.isTestNet,
     );

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -117,5 +117,8 @@ mod test {
 //Output the closest checkpoint to a given blockheight
 #[wasm_bindgen]
 pub fn get_closest_checkpoint(block_height: i32, is_testnet: bool) -> Result<JsValue, JsValue> {
-    Ok(serde_wasm_bindgen::to_value(&get_checkpoint(block_height, is_testnet))?)
+    Ok(serde_wasm_bindgen::to_value(&get_checkpoint(
+        block_height,
+        is_testnet,
+    ))?)
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -129,11 +129,12 @@ struct NewAddress {
 //Generate the deafult address of a given encoded extended full viewing key
 #[wasm_bindgen]
 pub fn generate_default_payment_address(
-    enc_extsk: String,
+    enc_extfvk: String,
     is_testnet: bool,
 ) -> Result<JsValue, JsValue> {
-    let extsk = decode_extsk(&enc_extsk, is_testnet).map_err(|e| e.to_string())?;
-    let (def_index, def_address) = extsk.to_diversifiable_full_viewing_key().default_address();
+    let extfvk =
+        decode_extended_full_viewing_key(&enc_extfvk, is_testnet).map_err(|e| e.to_string())?;
+    let (def_index, def_address) = extfvk.to_diversifiable_full_viewing_key().default_address();
     Ok(serde_wasm_bindgen::to_value(&NewAddress {
         address: encode_payment_address(&def_address, is_testnet),
         diversifier_index: def_index.0.to_vec(),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -4,6 +4,7 @@ use pivx_primitives::consensus::{Parameters, MAIN_NETWORK, TEST_NETWORK};
 use wasm_bindgen::prelude::*;
 
 use pivx_primitives::sapling::PaymentAddress;
+use pivx_primitives::zip32::sapling::ExtendedFullViewingKey;
 use pivx_primitives::zip32::sapling::ExtendedSpendingKey;
 use pivx_primitives::zip32::AccountId;
 use pivx_primitives::zip32::DiversifierIndex;
@@ -46,14 +47,18 @@ pub fn decode_generic_address(
         Ok(GenericAddress::Transparent(to_address))
     }
 }
-pub fn decode_extsk(enc_extsk: &str, is_testnet: bool) -> Result<ExtendedSpendingKey, Box<dyn Error>> {
+pub fn decode_extsk(
+    enc_extsk: &str,
+    is_testnet: bool,
+) -> Result<ExtendedSpendingKey, Box<dyn Error>> {
     let enc_str: &str = if is_testnet {
         TEST_NETWORK.hrp_sapling_extended_spending_key()
     } else {
         MAIN_NETWORK.hrp_sapling_extended_spending_key()
     };
 
-    Ok(encoding::decode_extended_spending_key(enc_str, enc_extsk).map_err(|_| "Cannot decde extsk")?)
+    Ok(encoding::decode_extended_spending_key(enc_str, enc_extsk)
+        .map_err(|_| "Cannot decode extsk ")?)
 }
 
 pub fn encode_extsk(extsk: &ExtendedSpendingKey, is_testnet: bool) -> String {
@@ -73,6 +78,34 @@ pub fn encode_payment_address(addr: &PaymentAddress, is_testnet: bool) -> String
         MAIN_NETWORK.hrp_sapling_payment_address()
     };
     encoding::encode_payment_address(enc_str, addr)
+}
+
+pub fn decode_extended_full_viewing_key(
+    enc_extfvk: &str,
+    is_testnet: bool,
+) -> Result<ExtendedFullViewingKey, Box<dyn Error>> {
+    let enc_str: &str = if is_testnet {
+        TEST_NETWORK.hrp_sapling_extended_full_viewing_key()
+    } else {
+        MAIN_NETWORK.hrp_sapling_extended_full_viewing_key()
+    };
+
+    Ok(
+        encoding::decode_extended_full_viewing_key(enc_str, enc_extfvk)
+            .map_err(|_| "Cannot decode efvk")?,
+    )
+}
+
+pub fn encode_extended_full_viewing_key(
+    extfvk: &ExtendedFullViewingKey,
+    is_testnet: bool,
+) -> String {
+    let enc_str: &str = if is_testnet {
+        TEST_NETWORK.hrp_sapling_extended_full_viewing_key()
+    } else {
+        MAIN_NETWORK.hrp_sapling_extended_full_viewing_key()
+    };
+    encoding::encode_extended_full_viewing_key(enc_str, extfvk)
 }
 
 //Generate an extended spending key given a seed, coin type and account index
@@ -95,7 +128,10 @@ struct NewAddress {
 }
 //Generate the deafult address of a given encoded extended full viewing key
 #[wasm_bindgen]
-pub fn generate_default_payment_address(enc_extsk: String, is_testnet: bool) -> Result<JsValue, JsValue> {
+pub fn generate_default_payment_address(
+    enc_extsk: String,
+    is_testnet: bool,
+) -> Result<JsValue, JsValue> {
     let extsk = decode_extsk(&enc_extsk, is_testnet).map_err(|e| e.to_string())?;
     let (def_index, def_address) = extsk.to_diversifiable_full_viewing_key().default_address();
     Ok(serde_wasm_bindgen::to_value(&NewAddress {
@@ -128,4 +164,16 @@ pub fn generate_next_shielding_payment_address(
         address: encode_payment_address(&address, is_testnet),
         diversifier_index: new_index.0.to_vec(),
     })?)
+}
+
+// Generate the full viewing key given the extended spending key
+#[wasm_bindgen]
+pub fn generate_extended_full_viewing_key(
+    enc_extsk: String,
+    is_testnet: bool,
+) -> Result<JsValue, JsValue> {
+    let extsk = decode_extsk(&enc_extsk, is_testnet).map_err(|e| e.to_string())?;
+    let extfvk = extsk.to_extended_full_viewing_key();
+    let enc_extfvk = encode_extended_full_viewing_key(&extfvk, is_testnet);
+    Ok(serde_wasm_bindgen::to_value(&enc_extfvk)?)
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -142,11 +142,12 @@ pub fn generate_default_payment_address(
 // Generate the n_address-th valid payment address given the encoded extended full viewing key and a starting index
 #[wasm_bindgen]
 pub fn generate_next_shielding_payment_address(
-    enc_extsk: String,
+    enc_extfvk: String,
     diversifier_index: &[u8],
     is_testnet: bool,
 ) -> Result<JsValue, JsValue> {
-    let extsk = decode_extsk(&enc_extsk, is_testnet).map_err(|e| e.to_string())?;
+    let extfvk =
+        decode_extended_full_viewing_key(&enc_extfvk, is_testnet).map_err(|e| e.to_string())?;
     let mut diversifier_index = DiversifierIndex(
         diversifier_index
             .try_into()
@@ -155,7 +156,7 @@ pub fn generate_next_shielding_payment_address(
     diversifier_index
         .increment()
         .map_err(|_| "No valid indeces left")?;
-    let (new_index, address) = extsk
+    let (new_index, address) = extfvk
         .to_diversifiable_full_viewing_key()
         .find_address(diversifier_index)
         .ok_or("No valid indeces left")?; // There are so many valid addresses this should never happen


### PR DESCRIPTION
For many things (mainly generating addresses and checking balance) the spending authority is not needed. This PR adds the possibility to create a view only instance, where you can still sync and generate addresses, but you cannot  create transactions. A view only mode instance can gain spending authority by inserting the spending key