### PR TITLE
Make ShieldData self contained

### DIFF
--- a/js/pivx_shield.js
+++ b/js/pivx_shield.js
@@ -204,10 +204,11 @@ export class PIVXShield {
   }
 
   /**
-   * Creates a PIVXShield object from a ShieldData
-   * @param {ShieldData} shieldData - shield data
+   * Creates a PIVXShield object from shieldData
+   * @param {String} data - output of save() function
    */
-  static async load(shieldData) {
+  static async load(data) {
+    const shieldData = JSON.parse(data);
     const shieldWorker = new Worker(
       new URL("worker_start.js", import.meta.url),
     );


### PR DESCRIPTION
save and load the extended full viewing key in place of a useless default address in this way:

- `ShieldData` is self contained and we can create a full view instance only from it
- `save` and `load` are no longer async
- On MPW we don't have to save separately `ShieldData` and `extfvk`