### PR TITLE
Use array for diversifierIndex

### DIFF
--- a/js/pivx_shield.js
+++ b/js/pivx_shield.js
@@ -26,7 +26,7 @@ export class PIVXShield {
    * Diversifier index of the last generated address.
    * @private
    */
-  #diversifierIndex = new Uint8Array(11);
+  #diversifierIndex = new Array(11).fill(0);
 
   /**
    * @type {boolean}


### PR DESCRIPTION
Use array in place of Uint8Array for 2 reasons:

-  Uint8Array does not work well with JSON.stringlify and JSON.load
- `generate_next_shielding_payment_address` returns an array anyways and not a Uint8Array