### PR TITLE
Add main to package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -6,6 +6,7 @@
     "*"
   ],
   "module": "pivx_shield.js",
+  "main": "pivx_shield.js",
   "typings": "pivx_shield.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Vite didn't recognize the package because the `main` key was missing. This PR adds it.