### PR TITLE
Add option to send memos

### DIFF
--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -31,6 +31,7 @@ interface Transaction {
   useShieldInputs: boolean;
   utxos: UTXO[];
   transparentChangeAddress: string;
+  memo: string;
 }
 
 interface CreateTransactionReturnValue {
@@ -359,6 +360,7 @@ export class PIVXShield {
     useShieldInputs = true,
     utxos,
     transparentChangeAddress,
+    memo = "",
   }: Transaction) {
     if (!this.extsk) {
       throw new Error("You cannot create a transaction in view only mode!");
@@ -380,6 +382,7 @@ export class PIVXShield {
           amount,
           block_height: blockHeight,
           is_testnet: this.isTestnet,
+          memo,
         },
       );
 

--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -22,6 +22,7 @@ interface TransactionResult {
   decrypted_notes: [Note, string][];
   commitment_tree: string;
   nullifiers: string[];
+  memos: string[];
 }
 
 interface Transaction {
@@ -313,12 +314,15 @@ export class PIVXShield {
         await this.removeSpentNotes(res.nullifiers);
       }
     }
-    return res.decrypted_notes.filter(
-      (note) =>
-        !this.unspentNotes.some(
-          (note2) => JSON.stringify(note2[0]) === JSON.stringify(note[0]),
-        ),
-    );
+    return {
+      notes: res.decrypted_notes.filter(
+        (note) =>
+          !this.unspentNotes.some(
+            (note2) => JSON.stringify(note2[0]) === JSON.stringify(note[0]),
+          ),
+      ),
+      memos: res.memos,
+    };
   }
 
   /**
@@ -391,7 +395,7 @@ export class PIVXShield {
     }
     this.pendingUnspentNotes.set(
       txid,
-      (await this.addTransaction(txhex, true)).map((n) => n[0]),
+      (await this.addTransaction(txhex, true)).notes.map((n) => n[0]),
     );
     return {
       hex: txhex,

--- a/src/transaction/test.rs
+++ b/src/transaction/test.rs
@@ -30,8 +30,10 @@ fn check_tx_decryption() {
     let key = UnifiedFullViewingKey::new(Some(skey.to_diversifiable_full_viewing_key()), None)
         .expect("Failed to create key");
     let mut comp_note = vec![];
-    let nullifiers =
+    let (nullifiers, memos) =
         handle_transaction_internal(&mut tree, tx, &key, true, &mut comp_note).unwrap();
+    assert_eq!(memos.len(), 1);
+    assert_eq!(memos[0], "");
     //This was a t-s tx
     assert_eq!(nullifiers.len(), 0);
     //Successfully decrypt exactly 1 note

--- a/src/transaction/test.rs
+++ b/src/transaction/test.rs
@@ -10,6 +10,7 @@ use pivx_client_backend::encoding;
 use pivx_client_backend::encoding::decode_extended_spending_key;
 use pivx_client_backend::keys::UnifiedFullViewingKey;
 use pivx_primitives::consensus::{BlockHeight, Network, Parameters, TEST_NETWORK};
+use pivx_primitives::memo::Memo;
 use pivx_primitives::merkle_tree::CommitmentTree;
 use pivx_primitives::sapling::value::NoteValue;
 use pivx_primitives::sapling::Node;
@@ -17,6 +18,7 @@ use pivx_primitives::sapling::Note;
 use pivx_primitives::sapling::Rseed::BeforeZip212;
 use std::error::Error;
 use std::io::Cursor;
+use std::str::FromStr;
 
 #[test]
 fn check_tx_decryption() {
@@ -91,12 +93,14 @@ pub async fn test_create_transaction() -> Result<(), Box<dyn Error>> {
     let mut path_vec = vec![];
     path.write(&mut path_vec)?;
     let path = hex::encode(path_vec);
+    let memo = Memo::from_str("Hello").map_err(|_| "Failed to encode memo")?;
     let tx = create_transaction_internal(
         Either::Left(vec![(note.clone(), path)]),
         &extended_spending_key,
         output,
         address,
         5 * 10e6 as u64,
+        &memo,
         BlockHeight::from_u32(317),
         Network::TestNetwork,
     )


### PR DESCRIPTION
Add the option to send and receive memos.
Received decrypted memos can be accessed through `addTransaction`. `decryptOnly` can be set to true if it's done at a later time than syncing

Closes #57 