### PR TITLE
Don't always subtract from amount

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -482,7 +482,7 @@ fn choose_utxos(
         }
     }
     if total < *amount + fee {
-        if total >= *amount {
+        if total >= *amount && *amount > fee {
             *amount -= fee;
         } else {
             Err("Not enough balance")?;
@@ -537,7 +537,7 @@ fn choose_notes(
     }
 
     if total < *amount + fee {
-        if total >= *amount {
+        if total >= *amount && *amount > fee {
             *amount -= fee
         } else {
             Err("Not enough balance")?;


### PR DESCRIPTION
Don't subtract from amount if the amount is smaller than the fee, in that case just return the error "Not enough balance"