### PR TITLE
Shield Activity Support

### DIFF
--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -504,6 +504,11 @@ export interface Note {
   rseed: number[];
 }
 
+export interface SimplifiedNote {
+  recipient: string;
+  value: number;
+}
+
 export interface ShieldData {
   extfvk: string;
   lastProcessedBlock: number;

--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -520,6 +520,13 @@ export class PIVXShield {
   }
 
   /**
+   * @param nullifier - A sapling nullifier
+   * @returns the Note corresponding to a given nullifier
+   */
+  getNoteFromNullifier(nullifier: string) {
+    return this.mapNullifierNote.get(nullifier);
+  }
+  /**
    * @returns sapling root
    */
   async getSaplingRoot(): Promise<string> {
@@ -542,13 +549,6 @@ export class PIVXShield {
     this.pendingSpentNotes = new Map();
     this.pendingUnspentNotes = new Map();
     this.mapNullifierNote = new Map();
-  }
-  /*
-   * @param nullifier - A shield spent nullifier
-   * @returns true if the provided nullifier belongs to the wallet
-   */
-  isMyNullifier(nullifier: string) {
-    return this.mapNullifierNote.has(nullifier);
   }
 }
 

--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -256,6 +256,7 @@ export class PIVXShield {
       diversifierIndex: this.diversifierIndex,
       unspentNotes: this.unspentNotes,
       isTestnet: this.isTestnet,
+      mapNullifierNote: Object.fromEntries(this.mapNullifierNote),
     });
   }
   /**
@@ -280,6 +281,9 @@ export class PIVXShield {
       shieldData.isTestnet,
       shieldData.lastProcessedBlock,
       shieldData.commitmentTree,
+    );
+    pivxShield.mapNullifierNote = new Map(
+      Object.entries(shieldData.mapNullifierNote),
     );
     pivxShield.diversifierIndex = shieldData.diversifierIndex;
     pivxShield.unspentNotes = shieldData.unspentNotes;

--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -283,11 +283,17 @@ export class PIVXShield {
       shieldData.commitmentTree,
     );
     pivxShield.mapNullifierNote = new Map(
-      Object.entries(shieldData.mapNullifierNote),
+      Object.entries(shieldData.mapNullifierNote ?? {}),
     );
     pivxShield.diversifierIndex = shieldData.diversifierIndex;
     pivxShield.unspentNotes = shieldData.unspentNotes;
-    return pivxShield;
+
+    // Shield activity update: mapNullifierNote must be present in the shieldData
+    let success = true;
+    if (!shieldData.mapNullifierNote) {
+      success = false;
+    }
+    return { pivxShield, success };
   }
 
   /**

--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -295,6 +295,28 @@ export class PIVXShield {
     this.lastProcessedBlock = block.height;
   }
 
+
+  /**
+   *
+   * @param note - Note and its corresponding witness
+   * Generate the nullifier for a given pair note, witness
+   */
+  async generateNullifierFromNote(note: [Note, String]) {
+    return await this.callWorker<string>(
+      "get_nullifier_from_note",
+      note,
+      this.extfvk,
+      this.isTestnet,
+    );
+  }
+
+  private async getShieldAddressFromNote(note: Note) {
+    return await this.callWorker<string>(
+      "encode_payment_address",
+      this.isTestnet,
+      note.recipient,
+    );
+  }
   async addTransaction(hex: string, decryptOnly = false) {
     const res = await this.callWorker<TransactionResult>(
       "handle_transaction",

--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -317,6 +317,17 @@ export class PIVXShield {
       note.recipient,
     );
   }
+  async decryptTransactionOutputs(hex: string) {
+    const res = await this.addTransaction(hex, true);
+    const simplifiedNotes = [];
+    for (const [note, _] of res) {
+      simplifiedNotes.push({
+        value: note.value,
+        recipient: await this.getShieldAddressFromNote(note),
+      });
+    }
+    return simplifiedNotes;
+  }
   async addTransaction(hex: string, decryptOnly = false) {
     const res = await this.callWorker<TransactionResult>(
       "handle_transaction",

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -23,6 +23,7 @@ use pivx_primitives::transaction::components::{OutPoint, TxOut};
 pub use pivx_primitives::transaction::fees::fixed::FeeRule;
 pub use pivx_primitives::transaction::Transaction;
 pub use pivx_primitives::zip32::AccountId;
+use pivx_primitives::zip32::ExtendedFullViewingKey;
 pub use pivx_primitives::zip32::ExtendedSpendingKey;
 pub use pivx_primitives::zip32::Scope;
 pub use pivx_proofs::prover::LocalTxProver;
@@ -276,17 +277,26 @@ pub fn get_nullifier_from_note(
 ) -> Result<JsValue, JsValue> {
     let extfvk =
         decode_extended_full_viewing_key(&enc_extfvk, is_testnet).map_err(|e| e.to_string())?;
+    let (note, hex_witness): (Note, String) = serde_wasm_bindgen::from_value(note_data)?;
+    let ser_nullifiers =
+        get_nullifier_from_note_internal(extfvk, note, hex_witness).map_err(|e| e.to_string())?;
+    Ok(serde_wasm_bindgen::to_value(&ser_nullifiers)?)
+}
+
+pub fn get_nullifier_from_note_internal(
+    extfvk: ExtendedFullViewingKey,
+    note: Note,
+    hex_witness: String,
+) -> Result<String, Box<dyn Error>> {
     let nullif_key = extfvk
         .to_diversifiable_full_viewing_key()
         .to_nk(Scope::External);
-    let (note, hex_witness): (Note, String) = serde_wasm_bindgen::from_value(note_data)?;
     let witness = Cursor::new(hex::decode(hex_witness).map_err(|e| e.to_string())?);
     let path = IncrementalWitness::<Node>::read(witness)
         .map_err(|_| "Cannot read witness from buffer")?
         .path()
         .ok_or("Cannot find witness path")?;
-    let ser_nullifiers = hex::encode(note.nf(&nullif_key, path.position).0);
-    Ok(serde_wasm_bindgen::to_value(&ser_nullifiers)?)
+    Ok(hex::encode(note.nf(&nullif_key, path.position).0))
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/transaction/test.rs
+++ b/src/transaction/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::transaction::create_transaction_internal;
+use crate::transaction::{create_transaction_internal, get_nullifier_from_note_internal};
 
 use super::handle_transaction_internal;
 use either::Either;
@@ -15,6 +15,7 @@ use pivx_primitives::sapling::value::NoteValue;
 use pivx_primitives::sapling::Node;
 use pivx_primitives::sapling::Note;
 use pivx_primitives::sapling::Rseed::BeforeZip212;
+use pivx_primitives::zip32::Scope;
 use std::error::Error;
 use std::io::Cursor;
 
@@ -92,7 +93,7 @@ pub async fn test_create_transaction() -> Result<(), Box<dyn Error>> {
     path.write(&mut path_vec)?;
     let path = hex::encode(path_vec);
     let tx = create_transaction_internal(
-        Either::Left(vec![(note.clone(), path)]),
+        Either::Left(vec![(note.clone(), path.clone())]),
         &extended_spending_key,
         output,
         address,
@@ -108,7 +109,15 @@ pub async fn test_create_transaction() -> Result<(), Box<dyn Error>> {
         nullifier,
         "5269442d8022af933774f9f22775566d92089a151ba733f6d751f5bb65a7f56d"
     );
-    // When we implement mempool, test that new notes work correctly
+    // Verify that get_nullifier_from_note_internal yields the same nullifier
+    assert_eq!(
+        get_nullifier_from_note_internal(
+            extended_spending_key.to_extended_full_viewing_key(),
+            note.clone(),
+            path
+        )?,
+        "5269442d8022af933774f9f22775566d92089a151ba733f6d751f5bb65a7f56d"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR is needed to support shield activity on MPW, it is divided in 4 main parts:

-  Add the interface `SimplifiedNote` which is the structure we are actually going to send to MPW
- All nullifiers belonging to the wallet are stored in a map `f: nullifier --> SimplifiedNote`. In this way we can decrypt a `ShieldSpent` only by its nullifier.
- Add a function `decryptTransactionOutputs` which tries to decrypt the `ShieldOutput` of a transaction and returns their simplified version
- Make handle block return the list of transactions that belongs to the wallet
