### PR TITLE
Make TX_PROGRESS_LOCK atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1383,7 @@ name = "pivx-shield-rust"
 version = "1.1.6"
 dependencies = [
  "async_once",
+ "atomic_float",
  "console_error_panic_hook",
  "either",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ secp256k1 = "0.21.3"
 either = "1.13.0"
 wasm-bindgen-rayon = { version = "1.2.1", optional = true }
 rand_core = "0.6.4"
+atomic_float = "1.1.0"
 
 [dev-dependencies]
 tokio = { version = "1.40.0", features = ["full"] } 


### PR DESCRIPTION
Locking a Mutex is a slow operation that involves system calls. Since we only need to synchronize a single float variable, using an atomic is better.  Also we get rid of `lazy_static`, that makes the first initialization slower.