### PR TITLE
Add ability to use different URL than duddino.com for sapling params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,12 +78,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_once"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,14 +1376,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pivx-shield-rust"
 version = "1.1.6"
 dependencies = [
- "async_once",
  "atomic_float",
  "console_error_panic_hook",
  "either",
  "getrandom",
  "hex",
  "jubjub",
- "lazy_static",
  "pivx_client_backend",
  "pivx_primitives",
  "pivx_proofs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ multicore = ["pivx_proofs/multicore", "wasm-bindgen-rayon"]
 [dependencies]
 tokio = { version = "1.40.0", default-features = false, features = ["sync", "macros"] }
 rayon = "1.10.0"
-lazy_static = "1.5.0"
-async_once = "0.2.6"
 sha256 = { version = "1.5.0", default-features = false }
 getrandom = { version = "0.2.15", features = ["js"] }
 reqwest = { version = "0.12.0", features = ["blocking"] }

--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -542,8 +542,12 @@ export class PIVXShield {
    * But will be done lazily if note called explicitally.
    * @returns resolves when the sapling prover is loaded
    */
-  async loadSaplingProver() {
-    return await this.callWorker<void>("load_prover");
+  async loadSaplingProver(url?: string) {
+    if (url) {
+      return await this.callWorker<boolean>("load_prover_with_url", url);
+    } else {
+      return await this.callWorker<boolean>("load_prover");
+    }
   }
 
   /**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod checkpoint;
 mod keys;
 mod mainnet_checkpoints;
+mod prover;
 mod testnet_checkpoints;
 mod transaction;
 mod utils;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,0 +1,60 @@
+use pivx_proofs::prover::LocalTxProver;
+use reqwest::Client;
+use std::error::Error;
+use tokio::sync::OnceCell;
+use wasm_bindgen::prelude::*;
+
+static PROVER: OnceCell<LocalTxProver> = OnceCell::const_new();
+
+pub async fn get_prover() -> &'static LocalTxProver {
+    let default_urls = &["https://https://pivxla.bz", "https://duddino.com"];
+    for url in default_urls {
+        if let Ok(prover) = get_with_url(url).await {
+            return prover;
+        }
+    }
+    panic!("Failed to download prover");
+}
+
+/**
+ * gets prover using the specified url. If the prover has already been downloaded
+ * no request will be made
+ */
+pub async fn get_with_url(url: &str) -> Result<&'static LocalTxProver, Box<dyn Error>> {
+    PROVER
+        .get_or_try_init(|| async {
+            let c = Client::new();
+            let out_url = format!("{}/sapling-output.params", url);
+            let spend_url = format!("{}/sapling-spend.params", url);
+            let sapling_output_bytes = c.get(&out_url).send().await?.bytes().await?;
+            let sapling_spend_bytes = c.get(&spend_url).send().await?.bytes().await?;
+
+            if sha256::digest(&*sapling_output_bytes)
+                != "2f0ebbcbb9bb0bcffe95a397e7eba89c29eb4dde6191c339db88570e3f3fb0e4"
+            {
+                Err("Sha256 does not match for sapling output")?;
+            }
+
+            if sha256::digest(&*sapling_spend_bytes)
+                != "8e48ffd23abb3a5fd9c5589204f32d9c31285a04b78096ba40a79b75677efc13"
+            {
+                Err("Sha256 does not match for sapling spend")?;
+            }
+            Ok(LocalTxProver::from_bytes(
+                &sapling_spend_bytes,
+                &sapling_output_bytes,
+            ))
+        })
+        .await
+}
+
+#[wasm_bindgen]
+pub async fn load_prover() -> bool {
+    get_prover().await;
+    true
+}
+
+#[wasm_bindgen]
+pub async fn load_prover_with_url(url: &str) -> bool {
+    get_with_url(url).await.is_ok()
+}


### PR DESCRIPTION
Use the newer OnceLock and remove lazy_static and async_once dependencies.
Add the ability to use a different URL by calling `load_prover(url)`.
Added pivx labs as default server and set duddino.com as backup