### PR TITLE
Fix sapling test download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1268,6 +1284,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
+ "proptest",
  "rand",
  "reddsa",
  "serde",
@@ -1488,6 +1505,7 @@ dependencies = [
  "pivx_address",
  "pivx_encoding",
  "pivx_note_encryption",
+ "proptest",
  "rand",
  "rand_core",
  "ripemd",
@@ -1568,6 +1586,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1708,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1871,6 +1924,18 @@ name = "rustls-pki-types"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2356,6 +2421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2485,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ rand_core = "0.6.4"
 atomic_float = "1.1.0"
 
 [dev-dependencies]
-tokio = { version = "1.40.0", features = ["full"] } 
+tokio = { version = "1.40.0", features = ["full"] }
+pivx_primitives = { git = "https://github.com/Duddino/librustpivx", default-features = false, features = ["transparent-inputs", "test-dependencies"] }
 wasm-bindgen-test = "0.3.13"
 
 [profile.release]

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,12 +1,24 @@
+use pivx_primitives::sapling::prover::TxProver;
+
+#[cfg(test)]
+use pivx_primitives::sapling::prover::mock::MockTxProver;
+#[cfg(not(test))]
 use pivx_proofs::prover::LocalTxProver;
+
 use reqwest::Client;
 use std::error::Error;
 use tokio::sync::OnceCell;
 use wasm_bindgen::prelude::*;
 
-static PROVER: OnceCell<LocalTxProver> = OnceCell::const_new();
+#[cfg(not(test))]
+type ImplTxProver = LocalTxProver;
 
-pub async fn get_prover() -> &'static LocalTxProver {
+#[cfg(test)]
+type ImplTxProver = MockTxProver;
+
+static PROVER: OnceCell<ImplTxProver> = OnceCell::const_new();
+
+pub async fn get_prover() -> &'static impl TxProver {
     let default_urls = &["https://https://pivxla.bz", "https://duddino.com"];
     for url in default_urls {
         if let Ok(prover) = get_with_url(url).await {
@@ -20,7 +32,8 @@ pub async fn get_prover() -> &'static LocalTxProver {
  * gets prover using the specified url. If the prover has already been downloaded
  * no request will be made
  */
-pub async fn get_with_url(url: &str) -> Result<&'static LocalTxProver, Box<dyn Error>> {
+#[cfg(not(test))]
+pub async fn get_with_url(url: &str) -> Result<&'static impl TxProver, Box<dyn Error>> {
     PROVER
         .get_or_try_init(|| async {
             let c = Client::new();
@@ -46,6 +59,11 @@ pub async fn get_with_url(url: &str) -> Result<&'static LocalTxProver, Box<dyn E
             ))
         })
         .await
+}
+
+#[cfg(test)]
+pub async fn get_with_url(_url: &str) -> Result<&'static impl TxProver, Box<dyn Error>> {
+    Ok(PROVER.get_or_init(|| async { MockTxProver }).await)
 }
 
 #[wasm_bindgen]

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -19,7 +19,7 @@ type ImplTxProver = MockTxProver;
 static PROVER: OnceCell<ImplTxProver> = OnceCell::const_new();
 
 pub async fn get_prover() -> &'static impl TxProver {
-    let default_urls = &["https://https://pivxla.bz", "https://duddino.com"];
+    let default_urls = &["https://pivxla.bz", "https://duddino.com"];
     for url in default_urls {
         if let Ok(prover) = get_with_url(url).await {
             return prover;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -17,6 +17,7 @@ use crate::keys::GenericAddress;
 #[cfg(feature = "multicore")]
 use atomic_float::AtomicF32;
 pub use either::Either;
+use pivx_primitives::sapling::prover::TxProver;
 pub use pivx_primitives::sapling::{note::Note, Node, Nullifier};
 pub use pivx_primitives::transaction::builder::Builder;
 pub use pivx_primitives::transaction::components::Amount;
@@ -27,7 +28,6 @@ pub use pivx_primitives::zip32::AccountId;
 use pivx_primitives::zip32::ExtendedFullViewingKey;
 pub use pivx_primitives::zip32::ExtendedSpendingKey;
 pub use pivx_primitives::zip32::Scope;
-pub use pivx_proofs::prover::LocalTxProver;
 use rand_core::OsRng;
 
 use secp256k1::SecretKey;
@@ -550,7 +550,7 @@ fn prove_transaction(
     builder: Builder<'_, Network, OsRng>,
     nullifiers: Vec<String>,
     fee: u64,
-    prover: &LocalTxProver,
+    prover: &impl TxProver,
 ) -> Result<JSTransaction, Box<dyn Error>> {
     #[cfg(not(test))]
     return {


### PR DESCRIPTION
Mock sapling prover in tests, to avoid downloading it in unit tests.
Depends on #94 