### PR TITLE
Fix error when uuid is undefined

### DIFF
--- a/js/pivx_shield.ts
+++ b/js/pivx_shield.ts
@@ -126,6 +126,7 @@ export class PIVXShield {
     if (!PIVXShield.isInit) {
       PIVXShield.isInit = true;
       PIVXShield.shieldWorker.onmessage = (msg) => {
+        if (!msg.data.uuid) return;
         const promise = PIVXShield.promises.get(msg.data.uuid);
         if (!promise)
           throw new Error(


### PR DESCRIPTION
Fix error when uuid is undefined, this can happen if shield is created multiple times.