### PR TITLE
Fix fee calculation

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -425,12 +425,15 @@ pub async fn create_transaction_internal(
 
     let mut transparent_signing_set = TransparentSigningSet::new();
 
-    let (transparent_output_count, sapling_output_count) =
+    let (mut transparent_output_count, sapling_output_count) =
         if to_address.starts_with(network.hrp_sapling_payment_address()) {
             (0, 2)
         } else {
             (1, 2)
         };
+    if !change_address.starts_with(network.hrp_sapling_payment_address()) {
+        transparent_output_count += 1;
+    }
     let (nullifiers, change, fee) = match inputs {
         Either::Left(notes) => choose_notes(
             &mut builder,


### PR DESCRIPTION
Fee calculation was off when using low amount outputs, causing txs to fail.
This is because the change address output wasn't included in the fee calculation
Example of tx that would fail before:
https://explorer2.duddino.com/tx/04541b03516aef23c13268a4f116d350d155b2a144dd21239faac62b8aebfede